### PR TITLE
Fix console error > depMaps is not a function

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -9,8 +9,5 @@ var config = {
             quicklink: 'Rafaelcg_Quicklink/js/quicklink.umd',
             polyfillio: 'https://polyfill.io/v2/polyfill.umd.js?features=IntersectionObserver'
         }
-    },
-    deps: {
-        'quicklink': ['jquery']
     }
 };


### PR DESCRIPTION
Issue reported here: https://github.com/rafaelstz/magento2-quicklink/issues/4