### PR TITLE
:bug: avoid external links to minify

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -6,6 +6,14 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
+        <dev>
+            <js>
+                <minify_exclude>
+                    <quicklink>/libs/quicklink</quicklink>
+                    <polyfill>/v3/polyfill</polyfill>
+                </minify_exclude>
+            </js>
+        </dev>
         <quicklink>
             <general>
                 <active>1</active>


### PR DESCRIPTION
<!---
    Thank you for contributing.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
When enabled Magento Minify, the external JS can't be merged and minified

### Fixed Issues 
Added to config.xml which JS must be excluded from JS Minification

### Contribution checklist
- [ ] Pull request has a meaningful description of its purpose
- [ ] All commits are accompanied by meaningful commit messages
